### PR TITLE
fix: rename monthly price field

### DIFF
--- a/src/components/AddReviewForm.tsx
+++ b/src/components/AddReviewForm.tsx
@@ -71,7 +71,7 @@ const AddReviewForm: React.FC = () => {
 
   const errorsDefault = {
     1: { fields: { street: false, number: false } },
-    2: { fields: { startDate: false, endDate: false, montlyPrice: false } },
+    2: { fields: { startDate: false, endDate: false, monthlyPrice: false } },
     3: {
       fields: {
         summerTemperature: false,

--- a/src/components/review-steps/Step2RentalPeriod.tsx
+++ b/src/components/review-steps/Step2RentalPeriod.tsx
@@ -146,7 +146,7 @@ const Step2RentalPeriod: React.FC<Step2Props> = ({
           value={formData.price || ''}
           onChange={e => updateFormData({ price: parseFloat(e.target.value) || 0 })}
           placeholder="Ej: 800"
-          error={fieldErrors?.montlyPrice}
+          error={fieldErrors?.monthlyPrice}
         />
 
         <div className="mt-6">

--- a/src/validation/validateStep2.ts
+++ b/src/validation/validateStep2.ts
@@ -11,7 +11,7 @@ export interface ValidationResult {
 
 export const validateStep2 = (context: FormDataType): ValidationResult => {
   const { startYear, endYear, price, wouldRecommend } = context;
-  const fieldErrors = { startYear: false, montlyPrice: false, wouldRecommend: false };
+  const fieldErrors = { startYear: false, monthlyPrice: false, wouldRecommend: false };
 
   if (!startYear) {
     return {
@@ -25,7 +25,7 @@ export const validateStep2 = (context: FormDataType): ValidationResult => {
     return {
       isValid: false,
       message: 'El precio es obligatorio',
-      fieldErrors: { ...fieldErrors, montlyPrice: true },
+      fieldErrors: { ...fieldErrors, monthlyPrice: true },
     };
   }
 


### PR DESCRIPTION
## Summary
- rename montlyPrice field to monthlyPrice in validation and form handling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68add017e878832e95ecd47f6690ee1f