### PR TITLE
Add final CTA section with Chrome Store link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Header from './components/Header';
 import InputSection from './components/InputSection';
 import ChromeStoreSection from './components/ChromeStoreSection';
 import PictureSection from './components/PictureSection';
+import FinalCTASection from './components/FinalCTASection';
 import MapView from './components/MapView';
 import AddReviewForm from './components/AddReviewForm';
 import AuthCallback from './components/AuthCallback';
@@ -78,6 +79,8 @@ function App() {
             }
           />
         </Routes>
+
+        <FinalCTASection />
 
         <footer className="mx-auto mt-8 max-w-6xl py-6 text-center text-sm text-gray-500">
           <nav className="mb-2 flex flex-wrap items-center justify-center gap-x-4 gap-y-2">

--- a/src/components/FinalCTASection.tsx
+++ b/src/components/FinalCTASection.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const FinalCTASection: React.FC = () => {
+  return (
+    <section className="w-full bg-blue-50 py-16">
+      <div className="mx-auto max-w-4xl px-4 text-center">
+        <h2 className="mb-6 text-3xl font-bold">¿Listo para verificar caseros?</h2>
+        <p className="mx-auto mb-8 max-w-2xl text-lg text-gray-600">
+          Instala nuestra extensión de Chrome y empieza a evaluar caseros mientras navegas.
+        </p>
+        <a
+          href="https://chrome.google.com/webstore/category/extensions"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center rounded-lg bg-blue-600 px-8 py-3 text-lg font-medium text-white shadow-lg transition-colors hover:bg-blue-700"
+        >
+          Instalar extensión
+        </a>
+      </div>
+    </section>
+  );
+};
+
+export default FinalCTASection;


### PR DESCRIPTION
## Summary
- add FinalCTASection component with Chrome Store link
- render FinalCTASection before the footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aef2827cd0832e869bfc5f970b67e2