### PR TITLE
Add how-it-works section to home page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { Toaster } from 'react-hot-toast';
 
 // Import our components
 import Header from './components/Header';
+import HeroSection from './components/HeroSection';
+import HowItWorksSection from './components/HowItWorksSection';
 import InputSection from './components/InputSection';
 import ChromeStoreSection from './components/ChromeStoreSection';
 import PictureSection from './components/PictureSection';
@@ -71,6 +73,8 @@ function App() {
             path="/"
             element={
               <>
+                <HeroSection />
+                <HowItWorksSection />
                 <InputSection />
                 <ChromeStoreSection />
                 <PictureSection />

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const HeroSection: React.FC = () => {
+  return (
+    <section className="w-full bg-gray-50 py-24">
+      <div className="mx-auto max-w-6xl px-4 text-center">
+        <h1 className="text-4xl font-bold text-gray-800">Casero Verificado</h1>
+        <p className="mt-4 text-lg text-gray-600">
+          Comparte y consulta experiencias reales de otros inquilinos.
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default HeroSection;
+

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { MagnifyingGlassIcon, PencilSquareIcon, GlobeAltIcon } from '@heroicons/react/24/outline';
+
+const steps = [
+  {
+    title: 'Busca la dirección',
+    description: 'Encuentra el inmueble que quieres evaluar.',
+    icon: MagnifyingGlassIcon,
+  },
+  {
+    title: 'Comparte tu experiencia',
+    description: 'Escribe una reseña anónima sobre tu casero.',
+    icon: PencilSquareIcon,
+  },
+  {
+    title: 'Ayuda a otros inquilinos',
+    description: 'Contribuye a un mercado de alquiler más transparente.',
+    icon: GlobeAltIcon,
+  },
+];
+
+const HowItWorksSection: React.FC = () => {
+  return (
+    <section className="w-full bg-white py-16">
+      <div className="mx-auto max-w-6xl px-4 text-center">
+        <h2 className="mb-12 text-3xl font-bold">¿Cómo funciona?</h2>
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+          {steps.map((step, index) => (
+            <div key={index} className="flex flex-col items-center text-center">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-[#F97316] text-white">
+                <step.icon className="h-8 w-8" />
+              </div>
+              <h3 className="mb-2 text-xl font-semibold">{step.title}</h3>
+              <p className="text-gray-600">{step.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HowItWorksSection;
+


### PR DESCRIPTION
## Summary
- add hero and how-it-works sections with icons and responsive grid
- render new section between hero and address input on landing page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aef2882340832ea9f8dc9312659094